### PR TITLE
Fix typos on docs (remove Optional and change array to IterableIterator)

### DIFF
--- a/@simulcast/core/EventRegistry.ts
+++ b/@simulcast/core/EventRegistry.ts
@@ -2,7 +2,7 @@ import type { EventHandler } from "./EventHandler.ts";
 import type { EventTypeDictionary } from "./EventTypeDictionary.ts";
 
 /**
- * Registry of event names to array of handlers.
+ * Registry of event names to IterableIterator of handlers.
  *
  * @see {@linkcode EventHandler}
  * @see {@linkcode EventTypeDictionary}

--- a/@simulcast/core/broadcast.ts
+++ b/@simulcast/core/broadcast.ts
@@ -19,7 +19,7 @@ import { on } from "./on.ts";
  * emitEvent("Nope"); // Nothing happens
  * ```
  * @template Events Event registry.
- * @param registry Optional record of event names mapped to an array of handlers.
+ * @param registry Optional record of event names mapped to an IterableIterator of handlers.
  * @param overrides Overrides of the default {@linkcode BroadcastObject} methods and properties.
  * @returns Object with `emit` and `on` functions.
  */

--- a/@simulcast/core/emit.ts
+++ b/@simulcast/core/emit.ts
@@ -19,7 +19,7 @@ import type { EventTypeDictionary } from "./EventTypeDictionary.ts";
  * emitEvent("data");
  * ```
  * @template Events Event registry.
- * @param eventRegistry Record of event names mapped to an array of handlers.
+ * @param eventRegistry Record of event names mapped to an IterableIterator of handlers.
  * @returns Curried function with `eventRegistry` in context.
  */
 export const emit = <Events extends EventTypeDictionary>(

--- a/@simulcast/core/on.ts
+++ b/@simulcast/core/on.ts
@@ -27,7 +27,7 @@ import type { EventTypeDictionary } from "./EventTypeDictionary.ts";
  * emitEvent("Will not log");
  * ```
  * @template Events Event registry.
- * @param eventRegistry Record of event names mapped to an array of handlers.
+ * @param eventRegistry Record of event names mapped to an IterableIterator of handlers.
  * @returns Curried function with `eventRegistry` in context.
  */
 export const on = <Events extends EventTypeDictionary>(

--- a/@simulcast/preact/useBroadcast.ts
+++ b/@simulcast/preact/useBroadcast.ts
@@ -36,7 +36,7 @@ import { useBroadcastProxyHandler } from "./useBroadcastProxyHandler.ts";
  * };
  * ```
  * @template Events Event registry.
- * @param registry Optional record of event names mapped to an array of handlers.
+ * @param registry Record of event names mapped to an IterableIterator of handlers.
  * @returns An object that gives access to the broadcast hooked to preact.
  */
 export const useBroadcast = <Events extends EventTypeDictionary>(

--- a/@simulcast/react/useBroadcast.ts
+++ b/@simulcast/react/useBroadcast.ts
@@ -38,7 +38,7 @@ import { useEffect, useMemo } from "react";
  * };
  * ```
  * @template Events Event registry.
- * @param registry Optional record of event names mapped to an array of handlers.
+ * @param registry Record of event names mapped to an IterableIterator of handlers.
  * @returns An object that gives access to the broadcast hooked to React.
  */
 export const useBroadcast = <Events extends EventTypeDictionary>(

--- a/@simulcast/vue/useBroadcast.ts
+++ b/@simulcast/vue/useBroadcast.ts
@@ -40,7 +40,7 @@ const broadcastMemo = new Map<
  * </template>
  * ```
  * @template Events Event registry.
- * @param registry Optional record of event names mapped to an array of handlers.
+ * @param registry Record of event names mapped to an IterableIterator of handlers.
  * @returns An object that gives access to the broadcast hooked to React.
  */
 export const useBroadcast = <Events extends EventTypeDictionary>(


### PR DESCRIPTION
`@simulcast` docs are outdated, this fixes that.

1. Remove `Optional` from non-optional arguments.
2. Change `array` with `IterableIterator` to better reflect reality.