### PR TITLE
Fix `jsxImportSource` issues.

### DIFF
--- a/@coven/pair/README.md
+++ b/@coven/pair/README.md
@@ -1,3 +1,4 @@
+<!-- deno-coverage-ignore-file -->
 <img alt="Coven Engineering Pair logo" src="https://raw.githubusercontent.com/covenengineering/libraries/main/@coven/pair/logo.svg" height="108" />
 
 [![JSR](https://jsr.io/badges/@coven/pair)](https://coven.to/pair)

--- a/@coven/pair/deno.json
+++ b/@coven/pair/deno.json
@@ -1,9 +1,5 @@
 {
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
-	"compilerOptions": {
-		"jsx": "react-jsx",
-		"jsxImportSource": "preact"
-	},
 	"exports": {
 		"./preact": "./preact/mod.ts",
 		"./react": "./react/mod.ts"
@@ -11,7 +7,7 @@
 	"imports": {
 		"@types/react": "npm:@types/react@^19.2.7",
 		"@types/react-dom": "npm:@types/react-dom@^19.2.3",
-		"preact": "npm:preact@^10.28.0",
+		"preact": "npm:preact@^10.28.1",
 		"preact-render-to-string": "npm:preact-render-to-string@^6.6.4",
 		"react": "npm:react@^19.2.3",
 		"react-dom": "npm:react-dom@^19.2.3"

--- a/@coven/pair/preact/PairedRenderFunction.ts
+++ b/@coven/pair/preact/PairedRenderFunction.ts
@@ -6,6 +6,7 @@ import type { Attributes, VNode } from "preact";
  *
  * @example
  * ```tsx
+ * /** @jsxImportSource preact *\/
  * import { createElement, Fragment } from "preact";
  *
  * const Example: PairedRenderFunction<() => number> = hook =>

--- a/@coven/pair/preact/pair.ts
+++ b/@coven/pair/preact/pair.ts
@@ -6,6 +6,7 @@ import type { PairedComponentProperties } from "./PairedComponentProperties.ts";
  *
  * @example
  * ```tsx
+ * /** @jsxImportSource preact *\/
  * import { useState } from "preact/hooks";
  *
  * const useCount = (initialCount: number) => {

--- a/@coven/pair/preact/tests/preact.test.ts
+++ b/@coven/pair/preact/tests/preact.test.ts
@@ -1,16 +1,17 @@
 import { pair, type PairedComponentProperties } from "@coven/pair/preact";
 import { assertStrictEquals } from "@std/assert";
 import { renderToString } from "preact-render-to-string";
-import { useState } from "preact/hooks";
+import { useCallback, useState } from "preact/hooks";
+import { jsx } from "preact/jsx-runtime";
 
 const Render = (usePairedState: typeof useState) => {
 	const [count, setCount] = usePairedState(0);
-
-	return (
-		<button onClick={() => setCount(count + 1)} type="button">
-			{count}
-		</button>
+	const onClick = useCallback(
+		() => setCount((currentCount) => currentCount + 1),
+		[],
 	);
+
+	return jsx("button", { children: count, onClick, type: "button" });
 };
 
 const Wanted = ({ children }: PairedComponentProperties<typeof useState>) =>
@@ -24,8 +25,8 @@ Deno.test(
 	"Generated HTML with a prop should be the same from using `pair` or doing everything manually",
 	() =>
 		assertStrictEquals(
-			renderToString(<PairedState key={key}>{Render}</PairedState>),
-			renderToString(<Wanted key={key}>{Render}</Wanted>),
+			renderToString(jsx(PairedState, { key, children: Render })),
+			renderToString(jsx(Wanted, { key, children: Render })),
 		),
 );
 
@@ -33,8 +34,8 @@ Deno.test(
 	"Generated HTML should be the same from using `pair` or doing everything manually",
 	() =>
 		assertStrictEquals(
-			renderToString(<PairedState>{Render}</PairedState>),
-			renderToString(<Wanted>{Render}</Wanted>),
+			renderToString(jsx(PairedState, { children: Render })),
+			renderToString(jsx(Wanted, { children: Render })),
 		),
 );
 

--- a/@coven/pair/react/tests/react.test.ts
+++ b/@coven/pair/react/tests/react.test.ts
@@ -1,17 +1,21 @@
-/** @jsxImportSource react */
 import { pair, type PairedComponentProperties } from "@coven/pair/react";
 import { assertStrictEquals } from "@std/assert";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { renderToString } from "react-dom/server";
+import { jsx } from "react/jsx-runtime";
 
 const Render = (usePairedState: typeof useState) => {
 	const [count, setCount] = usePairedState(0);
-
-	return (
-		<button onClick={() => setCount(count + 1)} type="button">
-			{count}
-		</button>
+	const onClick = useCallback(
+		() => setCount((currentCount) => currentCount + 1),
+		[],
 	);
+
+	return jsx("button", {
+		children: count,
+		onClick,
+		type: "button",
+	});
 };
 
 const Wanted = ({ children }: PairedComponentProperties<typeof useState>) =>
@@ -25,8 +29,8 @@ Deno.test(
 	"Generated HTML with a prop should be the same from using `pair` or doing everything manually",
 	() =>
 		assertStrictEquals(
-			renderToString(<PairedState key={key}>{Render}</PairedState>),
-			renderToString(<Wanted key={key}>{Render}</Wanted>),
+			renderToString(jsx(PairedState, { key, children: Render })),
+			renderToString(jsx(Wanted, { key, children: Render })),
 		),
 );
 
@@ -34,8 +38,8 @@ Deno.test(
 	"Generated HTML should be the same from using `pair` or doing everything manually",
 	() =>
 		assertStrictEquals(
-			renderToString(<PairedState>{Render}</PairedState>),
-			renderToString(<Wanted>{Render}</Wanted>),
+			renderToString(jsx(PairedState, { children: Render })),
+			renderToString(jsx(Wanted, { children: Render })),
 		),
 );
 

--- a/@simulcast/preact/deno.json
+++ b/@simulcast/preact/deno.json
@@ -8,7 +8,7 @@
 	"imports": {
 		"@testing-library/preact": "npm:@testing-library/preact@^3.2.4",
 		"@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1",
-		"preact": "npm:preact@^10.28.0"
+		"preact": "npm:preact@^10.28.1"
 	},
 	"name": "@simulcast/preact",
 	"version": "0.8.5"


### PR DESCRIPTION
For some reason `jsxImportSource` is not working properly in the last version of Deno (some conflict with whatever is set in `deno.json`. They haven't considered cases where one might have `preact` and `react` in the same project 😞 