### PR TITLE
@coven/math followup

### DIFF
--- a/@coven/compare/deno.json
+++ b/@coven/compare/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/compare",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/constants/deno.json
+++ b/@coven/constants/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/constants",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/cron/deno.json
+++ b/@coven/cron/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/cron",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/cron/parse.ts
+++ b/@coven/cron/parse.ts
@@ -1,6 +1,6 @@
 import { build, getGroups } from "@coven/expression";
 import { entriesToObject, length, objectToEntries } from "@coven/iterables";
-import { memoFunction } from "@coven/memo";
+import { memo, memoFunction } from "@coven/memo";
 import type { KeyOf, Maybe, ReadonlyRecord } from "@coven/types";
 import type { CronObject } from "./CronObject.ts";
 import type { CronString } from "./CronString.ts";
@@ -43,6 +43,6 @@ export const parse: (expression: CronString) => Maybe<CronObject> =
 
 		return (
 			length(entries) === 0 ? undefined : (
-				entriesToObject(entries)
+				memo(entriesToObject(entries))
 			)) as Maybe<CronObject>;
 	});

--- a/@coven/cron/parseList.ts
+++ b/@coven/cron/parseList.ts
@@ -1,5 +1,5 @@
 import { iterableToArray, unique } from "@coven/iterables";
-import { memoFunction } from "@coven/memo";
+import { memo, memoFunction } from "@coven/memo";
 import type { Maybe } from "@coven/types";
 import type { ListField } from "./ListField.ts";
 import { isListString } from "./isListString.ts";
@@ -23,9 +23,13 @@ export const parseList: <Predicated extends number>(
 ) => Maybe<ListField<Predicated>> = memoFunction(
 	<Predicated extends number>(value: string) =>
 		(isListString(value) ?
-			iterableToArray(
-				unique(
-					parseListMap(value.split(LIST_EXPRESSION_SEPARATOR_TOKEN)),
+			memo(
+				iterableToArray(
+					unique(
+						parseListMap(
+							value.split(LIST_EXPRESSION_SEPARATOR_TOKEN),
+						),
+					),
 				),
 			)
 		:	undefined) as Maybe<ListField<Predicated>>,

--- a/@coven/cron/parseRange.ts
+++ b/@coven/cron/parseRange.ts
@@ -1,5 +1,6 @@
 import { entriesToObject } from "@coven/iterables";
 import { memo, memoFunction } from "@coven/memo";
+import { isUndefined } from "@coven/predicates";
 import type { Maybe } from "@coven/types";
 import type { RangeField } from "./RangeField.ts";
 import { isRangeString } from "./isRangeString.ts";
@@ -39,8 +40,8 @@ export const parseRange: <Predicated extends number>(
 			:	undefined;
 
 		return (
-			maybeRange?.from === maybeRange?.to ? maybeRange?.from
-			: maybeRange !== undefined ? memo(maybeRange)
-			: maybeRange) as Maybe<Predicated | RangeField<Predicated>>;
+			isUndefined(maybeRange) ? maybeRange
+			: maybeRange.from === maybeRange.to ? maybeRange.from
+			: memo(maybeRange)) as Maybe<Predicated | RangeField<Predicated>>;
 	},
 );

--- a/@coven/cron/parseRange.ts
+++ b/@coven/cron/parseRange.ts
@@ -1,5 +1,5 @@
 import { entriesToObject } from "@coven/iterables";
-import { memoFunction } from "@coven/memo";
+import { memo, memoFunction } from "@coven/memo";
 import type { Maybe } from "@coven/types";
 import type { RangeField } from "./RangeField.ts";
 import { isRangeString } from "./isRangeString.ts";
@@ -39,8 +39,8 @@ export const parseRange: <Predicated extends number>(
 			:	undefined;
 
 		return (
-			maybeRange?.from === maybeRange?.to ?
-				maybeRange?.from
-			:	maybeRange) as Maybe<Predicated | RangeField<Predicated>>;
+			maybeRange?.from === maybeRange?.to ? maybeRange?.from
+			: maybeRange !== undefined ? memo(maybeRange)
+			: maybeRange) as Maybe<Predicated | RangeField<Predicated>>;
 	},
 );

--- a/@coven/cron/tests/nextISODate.test.ts
+++ b/@coven/cron/tests/nextISODate.test.ts
@@ -1,38 +1,41 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { nextISODate } from "../nextISODate.ts";
 
 const testDate = nextISODate("1992-01-01T00:00:00.000Z");
 
 Deno.test("* * * * * gets next minute", () =>
-	assertEquals(testDate("* * * * *"), "1992-01-01T00:01:00.000Z"),
+	assertStrictEquals(testDate("* * * * *"), "1992-01-01T00:01:00.000Z"),
 );
 
 Deno.test("5 * * * * gets next hour's minute 5", () =>
-	assertEquals(testDate("5 * * * *"), "1992-01-01T00:05:00.000Z"),
+	assertStrictEquals(testDate("5 * * * *"), "1992-01-01T00:05:00.000Z"),
 );
 
 Deno.test("5 10-13 * * * gets next hour's minute 5", () =>
-	assertEquals(testDate("5 10-13 * * *"), "1992-01-01T10:05:00.000Z"),
+	assertStrictEquals(testDate("5 10-13 * * *"), "1992-01-01T10:05:00.000Z"),
 );
 
 Deno.test("* * 31 2 * returns nothing because it's an invalid date", () =>
-	assertEquals(testDate("* * 31 2 *"), undefined),
+	assertStrictEquals(testDate("* * 31 2 *"), undefined),
 );
 
 Deno.test("* * 30,31 2 * returns nothing because it's an invalid date", () =>
-	assertEquals(testDate("* * 30,31 2 *"), undefined),
+	assertStrictEquals(testDate("* * 30,31 2 *"), undefined),
 );
 
 Deno.test("* * 30,31 2 * returns nothing because it's an invalid date", () =>
-	assertEquals(testDate("* * 30,31 2 *"), undefined),
+	assertStrictEquals(testDate("* * 30,31 2 *"), undefined),
 );
 
 Deno.test("* * 29,30,31 2 * gets first minute of next february 29", () =>
-	assertEquals(testDate("* * 29,30,31 2 *"), "1992-02-29T00:00:00.000Z"),
+	assertStrictEquals(
+		testDate("* * 29,30,31 2 *"),
+		"1992-02-29T00:00:00.000Z",
+	),
 );
 
 Deno.test("* * * * * as an object gets next minute", () =>
-	assertEquals(
+	assertStrictEquals(
 		testDate({
 			dayOfMonth: "*",
 			dayOfWeek: "*",
@@ -45,11 +48,11 @@ Deno.test("* * * * * as an object gets next minute", () =>
 );
 
 Deno.test("5 * * * * as an object gets next hour's minute 5", () =>
-	assertEquals(testDate({ minute: 5 }), "1992-01-01T00:05:00.000Z"),
+	assertStrictEquals(testDate({ minute: 5 }), "1992-01-01T00:05:00.000Z"),
 );
 
 Deno.test("5 10-13 * * * as an object gets next hour's minute 5", () =>
-	assertEquals(
+	assertStrictEquals(
 		testDate({ hour: { from: 10, to: 13 }, minute: 5 }),
 		"1992-01-01T10:05:00.000Z",
 	),
@@ -57,13 +60,13 @@ Deno.test("5 10-13 * * * as an object gets next hour's minute 5", () =>
 
 Deno.test(
 	"* * 31 2 * as object returns nothing because it's an invalid date",
-	() => assertEquals(testDate({ dayOfMonth: 31, month: 2 }), undefined),
+	() => assertStrictEquals(testDate({ dayOfMonth: 31, month: 2 }), undefined),
 );
 
 Deno.test(
 	"* * 29,30,31 2 * as an object gets first minute of next february 29",
 	() =>
-		assertEquals(
+		assertStrictEquals(
 			testDate({ dayOfMonth: [29, 30, 31], month: 2 }),
 			"1992-02-29T00:00:00.000Z",
 		),

--- a/@coven/cron/tests/parse.test.ts
+++ b/@coven/cron/tests/parse.test.ts
@@ -1,6 +1,7 @@
 // This file is huge, but is because we have to cover quite a lot
 // deno-lint-ignore coven/max-lines
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { memo } from "@coven/memo";
+import { assertStrictEquals } from "@std/assert";
 import type { CronString } from "../CronString.ts";
 import { parse } from "../parse.ts";
 
@@ -39,216 +40,264 @@ const februaryBadDaysOfMonth = [
 Deno.test(
 	"a * token for all fields return object with all properties set to *",
 	() =>
-		assertEquals(parse("* * * * *"), {
-			dayOfMonth: "*",
-			dayOfWeek: "*",
-			hour: "*",
-			minute: "*",
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("* * * * *"),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: "*",
+				hour: "*",
+				minute: "*",
+				month: "*",
+			}),
+		),
 );
 
 Deno.test(
 	"a * token for all fields except minute return object with all properties set to * except minute",
 	() =>
-		assertEquals(parse("13 * * * *"), {
-			dayOfMonth: "*",
-			dayOfWeek: "*",
-			hour: "*",
-			minute: 13,
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("13 * * * *"),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: "*",
+				hour: "*",
+				minute: 13,
+				month: "*",
+			}),
+		),
 );
 
 Deno.test(
 	"a * token for all fields except hour return object with all properties set to * except hour",
 	() =>
-		assertEquals(parse("* 13 * * *"), {
-			dayOfMonth: "*",
-			dayOfWeek: "*",
-			hour: 13,
-			minute: "*",
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("* 13 * * *"),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: "*",
+				hour: 13,
+				minute: "*",
+				month: "*",
+			}),
+		),
 );
 
 Deno.test(
 	"a * token for all fields except dayOfMonth return object with all properties set to * except dayOfMonth",
 	() =>
-		assertEquals(parse("* * 13 * *"), {
-			dayOfMonth: 13,
-			dayOfWeek: "*",
-			hour: "*",
-			minute: "*",
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("* * 13 * *"),
+			memo({
+				dayOfMonth: 13,
+				dayOfWeek: "*",
+				hour: "*",
+				minute: "*",
+				month: "*",
+			}),
+		),
 );
 
 Deno.test(
 	"a * token for all fields except month return object with all properties set to * except month",
 	() =>
-		assertEquals(parse("* * * 10 *"), {
-			dayOfMonth: "*",
-			dayOfWeek: "*",
-			hour: "*",
-			minute: "*",
-			month: 10,
-		}),
+		assertStrictEquals(
+			parse("* * * 10 *"),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: "*",
+				hour: "*",
+				minute: "*",
+				month: 10,
+			}),
+		),
 );
 
 Deno.test(
 	"a * token for all fields except dayOfWeek return object with all properties set to * except dayOfWeek",
 	() =>
-		assertEquals(parse("* * * * 5"), {
-			dayOfMonth: "*",
-			dayOfWeek: 5,
-			hour: "*",
-			minute: "*",
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("* * * * 5"),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: 5,
+				hour: "*",
+				minute: "*",
+				month: "*",
+			}),
+		),
 );
 
 Deno.test("all fields set return object with all properties set", () =>
-	assertEquals(parse("13 13 13 10 5"), {
-		dayOfMonth: 13,
-		dayOfWeek: 5,
-		hour: 13,
-		minute: 13,
-		month: 10,
-	}),
+	assertStrictEquals(
+		parse("13 13 13 10 5"),
+		memo({
+			dayOfMonth: 13,
+			dayOfWeek: 5,
+			hour: 13,
+			minute: 13,
+			month: 10,
+		}),
+	),
 );
 
 Deno.test(
 	"all fields set with ranges return object with all properties set",
 	() =>
-		assertEquals(parse("12-13 12-13 12-13 9-10 4-5"), {
-			dayOfMonth: { from: 12, to: 13 },
-			dayOfWeek: { from: 4, to: 5 },
-			hour: { from: 12, to: 13 },
-			minute: { from: 12, to: 13 },
-			month: { from: 9, to: 10 },
-		}),
+		assertStrictEquals(
+			parse("12-13 12-13 12-13 9-10 4-5"),
+			memo({
+				dayOfMonth: { from: 12, to: 13 },
+				dayOfWeek: { from: 4, to: 5 },
+				hour: { from: 12, to: 13 },
+				minute: { from: 12, to: 13 },
+				month: { from: 9, to: 10 },
+			}),
+		),
 );
 
 Deno.test(
 	"all fields set with lists return object with all properties set",
 	() =>
-		assertEquals(parse("12,13 12,13 12,13 9,10 4,5"), {
-			dayOfMonth: [12, 13],
-			dayOfWeek: [4, 5],
-			hour: [12, 13],
-			minute: [12, 13],
-			month: [9, 10],
-		}),
+		assertStrictEquals(
+			parse("12,13 12,13 12,13 9,10 4,5"),
+			memo({
+				dayOfMonth: [12, 13],
+				dayOfWeek: [4, 5],
+				hour: [12, 13],
+				minute: [12, 13],
+				month: [9, 10],
+			}),
+		),
 );
 
 Deno.test(
 	"all fields set with lists with ranges return object with all properties set",
 	() =>
-		assertEquals(parse("11-12,13 11-12,13 11-12,13 8-9,10 3-4,5"), {
-			dayOfMonth: [{ from: 11, to: 12 }, 13],
-			dayOfWeek: [{ from: 3, to: 4 }, 5],
-			hour: [{ from: 11, to: 12 }, 13],
-			minute: [{ from: 11, to: 12 }, 13],
-			month: [{ from: 8, to: 9 }, 10],
-		}),
+		assertStrictEquals(
+			parse("11-12,13 11-12,13 11-12,13 8-9,10 3-4,5"),
+			memo({
+				dayOfMonth: [{ from: 11, to: 12 }, 13],
+				dayOfWeek: [{ from: 3, to: 4 }, 5],
+				hour: [{ from: 11, to: 12 }, 13],
+				minute: [{ from: 11, to: 12 }, 13],
+				month: [{ from: 8, to: 9 }, 10],
+			}),
+		),
 );
 
 Deno.test(
 	"0 17 * * mon,tue,wed,thu,fri turn days of week into their number equivalents",
 	() =>
-		assertEquals(parse("0 17 * * mon,tue,wed,thu,fri" as CronString), {
-			dayOfMonth: "*",
-			dayOfWeek: [1, 2, 3, 4, 5],
-			hour: 17,
-			minute: 0,
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("0 17 * * mon,tue,wed,thu,fri" as CronString),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: [1, 2, 3, 4, 5],
+				hour: 17,
+				minute: 0,
+				month: "*",
+			}),
+		),
 );
 
 Deno.test(
 	"00 06 * * MON-FRI turn days of week into their number equivalents and handle double digit starting with 0 values",
 	() =>
-		assertEquals(parse("00 06 * * MON-FRI" as CronString), {
-			dayOfMonth: "*",
-			dayOfWeek: { from: 1, to: 5 },
-			hour: 6,
-			minute: 0,
-			month: "*",
-		}),
+		assertStrictEquals(
+			parse("00 06 * * MON-FRI" as CronString),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: { from: 1, to: 5 },
+				hour: 6,
+				minute: 0,
+				month: "*",
+			}),
+		),
 );
 
 Deno.test("* * * Mar-oct MON-FRI handle month and day aliases", () =>
-	assertEquals(parse("* * * Mar-oct MON-FRI" as CronString), {
-		dayOfMonth: "*",
-		dayOfWeek: { from: 1, to: 5 },
-		hour: "*",
-		minute: "*",
-		month: { from: 3, to: 10 },
-	}),
+	assertStrictEquals(
+		parse("* * * Mar-oct MON-FRI" as CronString),
+		memo({
+			dayOfMonth: "*",
+			dayOfWeek: { from: 1, to: 5 },
+			hour: "*",
+			minute: "*",
+			month: { from: 3, to: 10 },
+		}),
+	),
 );
 
 Deno.test(
 	"all fields set with lists with ranges, but a mistake in hour return undefined",
 	() =>
-		assertEquals(
+		assertStrictEquals(
 			parse("11-12,13 11-12,24 11-12,13 8-9,10 3-4,5"),
 			undefined,
 		),
 );
 
 Deno.test("an invalid string return undefined", () =>
-	assertEquals(parse("INVALID" as CronString), undefined),
+	assertStrictEquals(parse("INVALID" as CronString), undefined),
 );
 
 Deno.test("an invalid date return undefined", () =>
-	assertEquals(parse("* * 31 2 *"), undefined),
+	assertStrictEquals(parse("* * 31 2 *"), undefined),
 );
 
 Deno.test("an invalid date return undefined", () =>
-	assertEquals(parse("* * 30 02 *"), undefined),
+	assertStrictEquals(parse("* * 30 02 *"), undefined),
 );
 
 Deno.test("an invalid date return undefined", () =>
-	assertEquals(parse("* * 31 feb *" as CronString), undefined),
+	assertStrictEquals(parse("* * 31 feb *" as CronString), undefined),
 );
 
 Deno.test("an invalid date return undefined", () =>
-	assertEquals(parse("* * 31 4 *"), undefined),
+	assertStrictEquals(parse("* * 31 4 *"), undefined),
 );
 
 Deno.test(
 	"a valid date containing an invalid one return it because there's a valid date",
 	() =>
-		assertEquals(parse("* * 31 jan,feb *" as CronString), {
-			dayOfMonth: 31,
-			dayOfWeek: "*",
-			hour: "*",
-			minute: "*",
-			month: [1, 2],
-		}),
+		assertStrictEquals(
+			parse("* * 31 jan,feb *" as CronString),
+			memo({
+				dayOfMonth: 31,
+				dayOfWeek: "*",
+				hour: "*",
+				minute: "*",
+				month: [1, 2],
+			}),
+		),
 );
 
 Deno.test("a list with duplicated values return flattened values", () =>
-	assertEquals(parse("1,2,3,1 * * * *" as CronString), {
-		dayOfMonth: "*",
-		dayOfWeek: "*",
-		hour: "*",
-		minute: [1, 2, 3],
-		month: "*",
-	}),
-);
-
-Deno.test(
-	"a list of ranges with duplicated values return flattened values",
-	() =>
-		assertEquals(parse("1-1,2-2,3-3,1-1 * * * *" as CronString), {
+	assertStrictEquals(
+		parse("1,2,3,1 * * * *" as CronString),
+		memo({
 			dayOfMonth: "*",
 			dayOfWeek: "*",
 			hour: "*",
 			minute: [1, 2, 3],
 			month: "*",
 		}),
+	),
+);
+
+Deno.test(
+	"a list of ranges with duplicated values return flattened values",
+	() =>
+		assertStrictEquals(
+			parse("1-1,2-2,3-3,1-1 * * * *" as CronString),
+			memo({
+				dayOfMonth: "*",
+				dayOfWeek: "*",
+				hour: "*",
+				minute: [1, 2, 3],
+				month: "*",
+			}),
+		),
 );
 
 februaryBadDaysOfMonth.forEach((februaryBadDayOfMonth) =>
@@ -264,19 +313,19 @@ februaryBadDaysOfMonth.forEach((februaryBadDayOfMonth) =>
 	Deno.test(
 		`* * ${februaryBadDayOfMonth} 2,3 * returns valid date because 3 is included`,
 		() =>
-			assertEquals(
-				{
+			assertStrictEquals(
+				memo({
 					...parse(`* * ${februaryBadDayOfMonth} 2,3 *`),
 					dayOfMonth: "*",
 					month: [2, 3],
-				} as const,
-				{
+				} as const),
+				memo({
 					dayOfMonth: "*",
 					dayOfWeek: "*",
 					hour: "*",
 					minute: "*",
 					month: [2, 3],
-				} as const,
+				} as const),
 			),
 	),
 );
@@ -285,18 +334,18 @@ februaryBadDaysOfMonth.forEach((februaryBadDayOfMonth) =>
 	Deno.test(
 		`* * ${februaryBadDayOfMonth} 2-4 * returns valid date because 3 is included`,
 		() =>
-			assertEquals(
-				{
+			assertStrictEquals(
+				memo({
 					...parse(`* * ${februaryBadDayOfMonth} 2-4 *`),
 					dayOfMonth: "*",
-				} as const,
-				{
+				} as const),
+				memo({
 					dayOfMonth: "*",
 					dayOfWeek: "*",
 					hour: "*",
 					minute: "*",
 					month: { from: 2, to: 4 },
-				} as const,
+				} as const),
 			),
 	),
 );

--- a/@coven/cron/tests/parseField.test.ts
+++ b/@coven/cron/tests/parseField.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { memo } from "@coven/memo";
+import { assertStrictEquals } from "@std/assert";
 import { parseField } from "../parseField.ts";
 
 Deno.test("* gets *", () => assertStrictEquals(parseField("*"), "*"));
@@ -8,11 +9,11 @@ Deno.test("Number gets that parsed number", () =>
 );
 
 Deno.test("List gets that list number", () =>
-	assertEquals(parseField("10,11,12,13"), [10, 11, 12, 13]),
+	assertStrictEquals(parseField("10,11,12,13"), memo([10, 11, 12, 13])),
 );
 
 Deno.test("Range gets that list range", () =>
-	assertEquals(parseField("10-13"), { from: 10, to: 13 }),
+	assertStrictEquals(parseField("10-13"), memo({ from: 10, to: 13 })),
 );
 
 Deno.test("Invalid string gets undefined", () =>

--- a/@coven/cron/tests/parseList.test.ts
+++ b/@coven/cron/tests/parseList.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals } from "@std/assert";
+import { memo } from "@coven/memo";
+import { assertStrictEquals } from "@std/assert";
 import { parseList } from "../parseList.ts";
 
 Deno.test("List with 10, 11 and 13 returns parsed list", () =>
-	assertEquals(parseList("10,11,13"), [10, 11, 13]),
+	assertStrictEquals(parseList("10,11,13"), memo([10, 11, 13])),
 );

--- a/@coven/cron/tests/parseRange.test.ts
+++ b/@coven/cron/tests/parseRange.test.ts
@@ -1,8 +1,9 @@
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { memo } from "@coven/memo";
+import { assertStrictEquals } from "@std/assert";
 import { parseRange } from "../parseRange.ts";
 
 Deno.test("Number 1 and a 13 returns parsed values", () =>
-	assertEquals(parseRange("1-13"), { from: 1, to: 13 }),
+	assertStrictEquals(parseRange("1-13"), memo({ from: 1, to: 13 })),
 );
 
 Deno.test("Number 13 and a 13 returns normalized 13", () =>

--- a/@coven/expression/deno.json
+++ b/@coven/expression/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/expression",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/expression/tests/exists.test.ts
+++ b/@coven/expression/tests/exists.test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { exists } from "../exists.ts";
 
 Deno.test("Number 13 adds a + to the right", () =>
-	assertEquals(exists(13), "13+"),
+	assertStrictEquals(exists(13), "13+"),
 );
 
 Deno.test("Number 1 and number 3 adds a + to the right", () =>
-	assertEquals(exists(1, 3), "13+"),
+	assertStrictEquals(exists(1, 3), "13+"),
 );

--- a/@coven/iterables/async/tests/count.test.ts
+++ b/@coven/iterables/async/tests/count.test.ts
@@ -1,5 +1,5 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { count } from "../count.ts";
 
 const countEvens = count((number: number) => number % 2 === 0);
@@ -7,18 +7,18 @@ const countAll = count((_) => true);
 
 Deno.test(
 	"Array of mixed numbers and an even counter returns amount of even numbers in the array",
-	async () => assertEquals(await countEvens([0, 1, 2, 3, 4]), 3),
+	async () => assertStrictEquals(await countEvens([0, 1, 2, 3, 4]), 3),
 );
 
 Deno.test("Empty array and an even counter returns 0", async () =>
-	assertEquals(await countEvens(EMPTY_ARRAY), 0),
+	assertStrictEquals(await countEvens(EMPTY_ARRAY), 0),
 );
 
 Deno.test("Array of odd numbers and an even counter returns 0", async () =>
-	assertEquals(await countEvens([1, 3, 5, 7]), 0),
+	assertStrictEquals(await countEvens([1, 3, 5, 7]), 0),
 );
 
 Deno.test(
 	"Array of mixed numbers and a counter with no filter returns full length",
-	async () => assertEquals(await countAll([0, 1, 2, 3, 4]), 5),
+	async () => assertStrictEquals(await countAll([0, 1, 2, 3, 4]), 5),
 );

--- a/@coven/iterables/async/tests/find.test.ts
+++ b/@coven/iterables/async/tests/find.test.ts
@@ -1,5 +1,5 @@
 import { isString } from "@coven/predicates";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { find } from "../find.ts";
 import { toIterable } from "../toIterable.ts";
 
@@ -8,7 +8,7 @@ const findString = find<number | string>(isString);
 Deno.test(
 	"Array of numbers and strings containing search matching item gets the first string that matches",
 	async () =>
-		assertEquals(
+		assertStrictEquals(
 			await findString(toIterable([0, 1, "foo", 2, "bar"])),
 			"foo",
 		),
@@ -17,13 +17,13 @@ Deno.test(
 Deno.test(
 	"Array of numbers without search matching item gets the first string",
 	async () =>
-		assertEquals(await findString(toIterable([0, 1, 2])), undefined),
+		assertStrictEquals(await findString(toIterable([0, 1, 2])), undefined),
 );
 
 Deno.test(
 	"Iterable of numbers and strings containing search matching item gets the first string that matches",
 	async () =>
-		assertEquals(
+		assertStrictEquals(
 			await findString(toIterable([0, 1, "foo", 2, "bar"])),
 			"foo",
 		),
@@ -32,5 +32,5 @@ Deno.test(
 Deno.test(
 	"Iterable of numbers without search matching item gets the first string",
 	async () =>
-		assertEquals(await findString(toIterable([0, 1, 2])), undefined),
+		assertStrictEquals(await findString(toIterable([0, 1, 2])), undefined),
 );

--- a/@coven/iterables/async/tests/head.test.ts
+++ b/@coven/iterables/async/tests/head.test.ts
@@ -1,5 +1,5 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { range } from "../../range.ts";
 import { drop } from "../drop.ts";
 import { head } from "../head.ts";
@@ -7,17 +7,17 @@ import { head } from "../head.ts";
 const array = [0, 1, 2];
 
 Deno.test("Array returns array first element", async () =>
-	assertEquals(await head(array), 0),
+	assertStrictEquals(await head(array), 0),
 );
 
 Deno.test("Iterable returns iterable's first element", async () =>
-	assertEquals(await head(range(1)(0)(2)), 0),
+	assertStrictEquals(await head(range(1)(0)(2)), 0),
 );
 
 Deno.test("Empty array returns undefined", async () =>
-	assertEquals(await head(EMPTY_ARRAY), undefined),
+	assertStrictEquals(await head(EMPTY_ARRAY), undefined),
 );
 
 Deno.test("Empty iterable returns undefined", async () =>
-	assertEquals(await head(drop(Infinity)(array)), undefined),
+	assertStrictEquals(await head(drop(Infinity)(array)), undefined),
 );

--- a/@coven/iterables/async/tests/join.test.ts
+++ b/@coven/iterables/async/tests/join.test.ts
@@ -1,5 +1,5 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { join } from "../join.ts";
 import { toIterable } from "../toIterable.ts";
 
@@ -8,31 +8,33 @@ const array = [0, 1, 2, 3];
 
 Deno.test(
 	"Array of numbers returns those numbers separated by spaces",
-	async () => assertEquals(await spaceJoin(array), "0 1 2 3"),
+	async () => assertStrictEquals(await spaceJoin(array), "0 1 2 3"),
 );
 
 Deno.test(
 	"Iterable of numbers returns those numbers separated by spaces",
-	async () => assertEquals(await spaceJoin(toIterable(array)), "0 1 2 3"),
+	async () =>
+		assertStrictEquals(await spaceJoin(toIterable(array)), "0 1 2 3"),
 );
 
 Deno.test("Empty array returns empty string", async () =>
-	assertEquals(await spaceJoin(EMPTY_ARRAY), ""),
+	assertStrictEquals(await spaceJoin(EMPTY_ARRAY), ""),
 );
 
 Deno.test("Empty iterable returns empty string", async () =>
-	assertEquals(await spaceJoin(toIterable(EMPTY_ARRAY)), ""),
+	assertStrictEquals(await spaceJoin(toIterable(EMPTY_ARRAY)), ""),
 );
 
 Deno.test(
 	"Iterable with empty strings returns spaces for each value",
-	async () => assertEquals(await spaceJoin(toIterable(["", "", ""])), "  "),
+	async () =>
+		assertStrictEquals(await spaceJoin(toIterable(["", "", ""])), "  "),
 );
 
 Deno.test(
 	"Iterable with undefined values returns empty stringified undefined values",
 	async () =>
-		assertEquals(
+		assertStrictEquals(
 			await spaceJoin(toIterable([undefined, undefined])),
 			"undefined undefined",
 		),

--- a/@coven/iterables/async/tests/length.test.ts
+++ b/@coven/iterables/async/tests/length.test.ts
@@ -1,21 +1,21 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { range } from "../../range.ts";
 import { length } from "../length.ts";
 import { toIterable } from "../toIterable.ts";
 
 Deno.test("Array returns length", async () =>
-	assertEquals(await length([0, 1, 2]), 3),
+	assertStrictEquals(await length([0, 1, 2]), 3),
 );
 
 Deno.test("Iterable returns length", async () =>
-	assertEquals(await length(range(1)(0)(2)), 3),
+	assertStrictEquals(await length(range(1)(0)(2)), 3),
 );
 
 Deno.test("Empty array returns 0", async () =>
-	assertEquals(await length(EMPTY_ARRAY), 0),
+	assertStrictEquals(await length(EMPTY_ARRAY), 0),
 );
 
 Deno.test("Empty iterable returns 0", async () =>
-	assertEquals(await length(toIterable(EMPTY_ARRAY)), 0),
+	assertStrictEquals(await length(toIterable(EMPTY_ARRAY)), 0),
 );

--- a/@coven/iterables/async/tests/reduce.test.ts
+++ b/@coven/iterables/async/tests/reduce.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { reduce } from "../reduce.ts";
 
 const add = (augend: number) => (addend: number) => addend + augend;
@@ -7,5 +7,5 @@ const sumFrom0 = sum(0);
 
 Deno.test(
 	"an array of numbers and a sum reducer returns the total sum",
-	async () => assertEquals(await sumFrom0([1, 2, 3]), 6),
+	async () => assertStrictEquals(await sumFrom0([1, 2, 3]), 6),
 );

--- a/@coven/iterables/deno.json
+++ b/@coven/iterables/deno.json
@@ -5,5 +5,5 @@
 		"./async": "./async/mod.ts"
 	},
 	"name": "@coven/iterables",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/iterables/tests/count.test.ts
+++ b/@coven/iterables/tests/count.test.ts
@@ -1,5 +1,5 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { count } from "../count.ts";
 
 const countEvens = count((number: number) => number % 2 === 0);
@@ -7,18 +7,18 @@ const countAll = count((_) => true);
 
 Deno.test(
 	"Array of mixed numbers and an even counter returns amount of even numbers in the array",
-	() => assertEquals(countEvens([0, 1, 2, 3, 4]), 3),
+	() => assertStrictEquals(countEvens([0, 1, 2, 3, 4]), 3),
 );
 
 Deno.test("Empty array and an even counter returns 0", () =>
-	assertEquals(countEvens(EMPTY_ARRAY), 0),
+	assertStrictEquals(countEvens(EMPTY_ARRAY), 0),
 );
 
 Deno.test("Array of odd numbers and an even counter returns 0", () =>
-	assertEquals(countEvens([1, 3, 5, 7]), 0),
+	assertStrictEquals(countEvens([1, 3, 5, 7]), 0),
 );
 
 Deno.test(
 	"Array of mixed numbers and a counter with no filter returns full length",
-	() => assertEquals(countAll([0, 1, 2, 3, 4]), 5),
+	() => assertStrictEquals(countAll([0, 1, 2, 3, 4]), 5),
 );

--- a/@coven/iterables/tests/find.test.ts
+++ b/@coven/iterables/tests/find.test.ts
@@ -1,26 +1,29 @@
 import { isString } from "@coven/predicates";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { find } from "../find.ts";
 
 const findString = find<number | string>(isString);
 
 Deno.test(
 	"Array of numbers and strings containing search matching item gets the first string that matches",
-	() => assertEquals(findString([0, 1, "foo", 2, "bar"]), "foo"),
+	() => assertStrictEquals(findString([0, 1, "foo", 2, "bar"]), "foo"),
 );
 
 Deno.test(
 	"Array of numbers without search matching item gets the first string",
-	() => assertEquals(findString([0, 1, 2]), undefined),
+	() => assertStrictEquals(findString([0, 1, 2]), undefined),
 );
 
 Deno.test(
 	"Iterable of numbers and strings containing search matching item gets the first string that matches",
 	() =>
-		assertEquals(findString(Iterator.from([0, 1, "foo", 2, "bar"])), "foo"),
+		assertStrictEquals(
+			findString(Iterator.from([0, 1, "foo", 2, "bar"])),
+			"foo",
+		),
 );
 
 Deno.test(
 	"Iterable of numbers without search matching item gets the first string",
-	() => assertEquals(findString(Iterator.from([0, 1, 2])), undefined),
+	() => assertStrictEquals(findString(Iterator.from([0, 1, 2])), undefined),
 );

--- a/@coven/iterables/tests/head.test.ts
+++ b/@coven/iterables/tests/head.test.ts
@@ -1,5 +1,5 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { drop } from "../drop.ts";
 import { head } from "../head.ts";
 import { range } from "../range.ts";
@@ -7,17 +7,17 @@ import { range } from "../range.ts";
 const array = [0, 1, 2];
 
 Deno.test("Array returns array first element", () =>
-	assertEquals(head(array), 0),
+	assertStrictEquals(head(array), 0),
 );
 
 Deno.test("Iterable returns iterable's first element", () =>
-	assertEquals(head(range(1)(0)(2)), 0),
+	assertStrictEquals(head(range(1)(0)(2)), 0),
 );
 
 Deno.test("Empty array returns undefined", () =>
-	assertEquals(head(EMPTY_ARRAY), undefined),
+	assertStrictEquals(head(EMPTY_ARRAY), undefined),
 );
 
 Deno.test("Empty iterable returns undefined", () =>
-	assertEquals(head(drop(Infinity)(array)), undefined),
+	assertStrictEquals(head(drop(Infinity)(array)), undefined),
 );

--- a/@coven/iterables/tests/join.test.ts
+++ b/@coven/iterables/tests/join.test.ts
@@ -1,34 +1,34 @@
 import { EMPTY_ARRAY } from "@coven/constants";
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { join } from "../join.ts";
 
 const spaceJoin = join(" ");
 const array = [0, 1, 2, 3];
 
 Deno.test("Array of numbers returns those numbers separated by spaces", () =>
-	assertEquals(spaceJoin(array), "0 1 2 3"),
+	assertStrictEquals(spaceJoin(array), "0 1 2 3"),
 );
 
 Deno.test("Iterable of numbers returns those numbers separated by spaces", () =>
-	assertEquals(spaceJoin(Iterator.from(array)), "0 1 2 3"),
+	assertStrictEquals(spaceJoin(Iterator.from(array)), "0 1 2 3"),
 );
 
 Deno.test("Empty array returns empty string", () =>
-	assertEquals(spaceJoin(EMPTY_ARRAY), ""),
+	assertStrictEquals(spaceJoin(EMPTY_ARRAY), ""),
 );
 
 Deno.test("Empty iterable returns empty string", () =>
-	assertEquals(spaceJoin(Iterator.from(EMPTY_ARRAY)), ""),
+	assertStrictEquals(spaceJoin(Iterator.from(EMPTY_ARRAY)), ""),
 );
 
 Deno.test("Iterable with empty strings returns spaces for each value", () =>
-	assertEquals(spaceJoin(Iterator.from(["", "", ""])), "  "),
+	assertStrictEquals(spaceJoin(Iterator.from(["", "", ""])), "  "),
 );
 
 Deno.test(
 	"Iterable with undefined values returns empty stringified undefined values",
 	() =>
-		assertEquals(
+		assertStrictEquals(
 			spaceJoin(Iterator.from([undefined, undefined])),
 			"undefined undefined",
 		),

--- a/@coven/iterables/tests/reduce.test.ts
+++ b/@coven/iterables/tests/reduce.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { reduce } from "../reduce.ts";
 
 const add = (augend: number) => (addend: number) => addend + augend;
@@ -6,5 +6,5 @@ const sum = reduce(add);
 const sumFrom0 = sum(0);
 
 Deno.test("an array of numbers and a sum reducer returns the total sum", () =>
-	assertEquals(sumFrom0([1, 2, 3]), 6),
+	assertStrictEquals(sumFrom0([1, 2, 3]), 6),
 );

--- a/@coven/math/deno.json
+++ b/@coven/math/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/math",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/math/numberFunction.ts
+++ b/@coven/math/numberFunction.ts
@@ -1,7 +1,6 @@
 import { memoFunction } from "@coven/memo";
 import { isFunction } from "@coven/predicates";
 import type { Unary } from "@coven/types";
-import { always } from "@coven/utils";
 import { isPrecise } from "./isPrecise.ts";
 import { numberToPrecise } from "./numberToPrecise.ts";
 import type { Precise } from "./precise.ts";
@@ -35,7 +34,7 @@ export type NumberFunction = Unary<
  */
 export const numberFunction = (
 	preciseFunction: PreciseFunction<Precise | number>,
-	fallback: NumberFunction = always,
+	fallback: NumberFunction,
 ): NumberFunction =>
 	memoFunction((right) => {
 		const preciseRight = numberToPrecise(right);

--- a/@coven/math/tests/calculate.test.ts
+++ b/@coven/math/tests/calculate.test.ts
@@ -70,3 +70,99 @@ Deno.test("2 + NaN = NaN", () =>
 Deno.test("Infinity + NaN = NaN", () =>
 	assertStrictEquals(calculate(Infinity).plus(NaN).total, NaN),
 );
+
+Deno.test("Infinity - 2 = Infinity", () =>
+	assertStrictEquals(calculate(Infinity).minus(2).total, Infinity),
+);
+
+Deno.test("NaN - 2 = NaN", () =>
+	assertStrictEquals(calculate(NaN).minus(2).total, NaN),
+);
+
+Deno.test("Infinity - Infinity = NaN", () =>
+	assertStrictEquals(calculate(Infinity).minus(Infinity).total, NaN),
+);
+
+Deno.test("2 - Infinity = -Infinity", () =>
+	assertStrictEquals(calculate(2).minus(Infinity).total, -Infinity),
+);
+
+Deno.test("NaN - Infinity = NaN", () =>
+	assertStrictEquals(calculate(NaN).minus(Infinity).total, NaN),
+);
+
+Deno.test("NaN - NaN = NaN", () =>
+	assertStrictEquals(calculate(NaN).minus(NaN).total, NaN),
+);
+
+Deno.test("2 - NaN = NaN", () =>
+	assertStrictEquals(calculate(2).minus(NaN).total, NaN),
+);
+
+Deno.test("Infinity - NaN = NaN", () =>
+	assertStrictEquals(calculate(Infinity).minus(NaN).total, NaN),
+);
+
+Deno.test("Infinity * 2 = Infinity", () =>
+	assertStrictEquals(calculate(Infinity).times(2).total, Infinity),
+);
+
+Deno.test("NaN * 2 = NaN", () =>
+	assertStrictEquals(calculate(NaN).times(2).total, NaN),
+);
+
+Deno.test("Infinity * Infinity = Infinity", () =>
+	assertStrictEquals(calculate(Infinity).times(Infinity).total, Infinity),
+);
+
+Deno.test("2 * Infinity = Infinity", () =>
+	assertStrictEquals(calculate(2).times(Infinity).total, Infinity),
+);
+
+Deno.test("NaN * Infinity = NaN", () =>
+	assertStrictEquals(calculate(NaN).times(Infinity).total, NaN),
+);
+
+Deno.test("NaN * NaN = NaN", () =>
+	assertStrictEquals(calculate(NaN).times(NaN).total, NaN),
+);
+
+Deno.test("2 * NaN = NaN", () =>
+	assertStrictEquals(calculate(2).times(NaN).total, NaN),
+);
+
+Deno.test("Infinity * NaN = NaN", () =>
+	assertStrictEquals(calculate(Infinity).times(NaN).total, NaN),
+);
+
+Deno.test("Infinity / 2 = Infinity", () =>
+	assertStrictEquals(calculate(Infinity).dividedBy(2).total, Infinity),
+);
+
+Deno.test("NaN / 2 = NaN", () =>
+	assertStrictEquals(calculate(NaN).dividedBy(2).total, NaN),
+);
+
+Deno.test("Infinity / Infinity = NaN", () =>
+	assertStrictEquals(calculate(Infinity).dividedBy(Infinity).total, NaN),
+);
+
+Deno.test("2 / Infinity = 0", () =>
+	assertStrictEquals(calculate(2).dividedBy(Infinity).total, 0),
+);
+
+Deno.test("NaN / Infinity = NaN", () =>
+	assertStrictEquals(calculate(NaN).dividedBy(Infinity).total, NaN),
+);
+
+Deno.test("NaN / NaN = NaN", () =>
+	assertStrictEquals(calculate(NaN).dividedBy(NaN).total, NaN),
+);
+
+Deno.test("2 / NaN = NaN", () =>
+	assertStrictEquals(calculate(2).dividedBy(NaN).total, NaN),
+);
+
+Deno.test("Infinity / NaN = NaN", () =>
+	assertStrictEquals(calculate(Infinity).dividedBy(NaN).total, NaN),
+);

--- a/@coven/memo/deno.json
+++ b/@coven/memo/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/memo",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/pair/deno.json
+++ b/@coven/pair/deno.json
@@ -13,5 +13,5 @@
 		"react-dom": "npm:react-dom@^19.2.5"
 	},
 	"name": "@coven/pair",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/parsers/deno.json
+++ b/@coven/parsers/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/parsers",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/parsers/tests/attempt.test.ts
+++ b/@coven/parsers/tests/attempt.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { attempt } from "../attempt.ts";
 
 const THROWS = true;
@@ -16,9 +16,9 @@ const throwingFunction = (shouldThrow: boolean) => {
 const safeFunction = attempt(throwingFunction);
 
 Deno.test("Returns expected value when function doesn't throw", () =>
-	assertEquals(safeFunction(DOES_NOT_THROW), "success"),
+	assertStrictEquals(safeFunction(DOES_NOT_THROW), "success"),
 );
 
 Deno.test("Returns undefined when function throw", () =>
-	assertEquals(safeFunction(THROWS), undefined),
+	assertStrictEquals(safeFunction(THROWS), undefined),
 );

--- a/@coven/parsers/tests/clone.test.ts
+++ b/@coven/parsers/tests/clone.test.ts
@@ -1,35 +1,47 @@
 import { EMPTY_ARRAY, EMPTY_OBJECT } from "@coven/constants";
 import type { StructuredData } from "@coven/types";
-import { assertEquals } from "@std/assert";
+import {
+	assertEquals,
+	assertNotStrictEquals,
+	assertStrictEquals,
+} from "@std/assert";
 import { clone } from "../clone.ts";
 
+/**
+ * Check structure is the same but identities are different.
+ */
+const assertClone = <T>(actual: T, expected: T) => (
+	assertEquals(actual, expected),
+	assertNotStrictEquals(actual, expected)
+);
+
 Deno.test("Cloning empty object returns copy of object", () =>
-	assertEquals(clone(EMPTY_OBJECT), EMPTY_OBJECT),
+	assertClone(clone(EMPTY_OBJECT), EMPTY_OBJECT),
 );
 
 Deno.test("Cloning object with a string returns copy of object", () =>
-	assertEquals(clone({ foo: "bar" }), { foo: "bar" }),
+	assertClone(clone({ foo: "bar" }), { foo: "bar" }),
 );
 
 Deno.test("Cloning empty array returns copy of empty array", () =>
-	assertEquals(clone(EMPTY_ARRAY), EMPTY_ARRAY),
+	assertClone(clone(EMPTY_ARRAY), EMPTY_ARRAY),
 );
 
 Deno.test("Cloning array with numbers returns copy of array", () =>
-	assertEquals(clone([1, 2, 3]), [1, 2, 3]),
+	assertClone(clone([1, 2, 3]), [1, 2, 3]),
 );
 
 Deno.test("Cloning string returns copy of string", () =>
-	assertEquals(clone("string"), "string"),
+	assertStrictEquals(clone("string"), "string"),
 );
 
 Deno.test("Cloning non serializable object returns undefined", () =>
-	assertEquals(
+	assertStrictEquals(
 		clone({ function: () => undefined } as unknown as StructuredData),
 		undefined,
 	),
 );
 
 Deno.test("Cloning number returns a copy of number", () =>
-	assertEquals(clone(13), 13),
+	assertStrictEquals(clone(13), 13),
 );

--- a/@coven/parsers/tests/parseBinary.test.ts
+++ b/@coven/parsers/tests/parseBinary.test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { parseBinary } from "../parseBinary.ts";
 
 Deno.test("Parsing valid binary string returns parsed value", () =>
-	assertEquals(parseBinary("101"), 0b101),
+	assertStrictEquals(parseBinary("101"), 0b101),
 );
 
 Deno.test("Parsing binary string with a dot returns parsed value", () =>
-	assertEquals(parseBinary("101.5"), 0b101),
+	assertStrictEquals(parseBinary("101.5"), 0b101),
 );
 
 Deno.test("Parsing invalid string returns undefined", () =>
-	assertEquals(parseBinary("invalid"), undefined),
+	assertStrictEquals(parseBinary("invalid"), undefined),
 );

--- a/@coven/parsers/tests/parseDecimal.test.ts
+++ b/@coven/parsers/tests/parseDecimal.test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { parseDecimal } from "../parseDecimal.ts";
 
 Deno.test("Parsing valid decimal string returns parsed value", () =>
-	assertEquals(parseDecimal("101"), 101),
+	assertStrictEquals(parseDecimal("101"), 101),
 );
 
 Deno.test("Parsing decimal string with a dot returns parsed value", () =>
-	assertEquals(parseDecimal("101.5"), 101),
+	assertStrictEquals(parseDecimal("101.5"), 101),
 );
 
 Deno.test("Parsing invalid string returns undefined", () =>
-	assertEquals(parseDecimal("invalid"), undefined),
+	assertStrictEquals(parseDecimal("invalid"), undefined),
 );

--- a/@coven/parsers/tests/parseFloatingPoint.test.ts
+++ b/@coven/parsers/tests/parseFloatingPoint.test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { parseFloatingPoint } from "../parseFloatingPoint.ts";
 
 Deno.test("Parsing valid float point string returns parsed value", () =>
-	assertEquals(parseFloatingPoint("101"), 101),
+	assertStrictEquals(parseFloatingPoint("101"), 101),
 );
 
 Deno.test("Parsing float point string with a dot returns parsed value", () =>
-	assertEquals(parseFloatingPoint("101.5"), 101.5),
+	assertStrictEquals(parseFloatingPoint("101.5"), 101.5),
 );
 
 Deno.test("Parsing invalid string returns undefined", () =>
-	assertEquals(parseFloatingPoint("invalid"), undefined),
+	assertStrictEquals(parseFloatingPoint("invalid"), undefined),
 );

--- a/@coven/parsers/tests/parseHexadecimal.test.ts
+++ b/@coven/parsers/tests/parseHexadecimal.test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { parseHexadecimal } from "../parseHexadecimal.ts";
 
 Deno.test("Parsing valid hexadecimal string returns parsed value", () =>
-	assertEquals(parseHexadecimal("101"), 0x1_01),
+	assertStrictEquals(parseHexadecimal("101"), 0x1_01),
 );
 
 Deno.test("Parsing hexadecimal string with a dot returns parsed value", () =>
-	assertEquals(parseHexadecimal("101.5"), 0x1_01),
+	assertStrictEquals(parseHexadecimal("101.5"), 0x1_01),
 );
 
 Deno.test("Parsing invalid string returns undefined", () =>
-	assertEquals(parseHexadecimal("invalid"), undefined),
+	assertStrictEquals(parseHexadecimal("invalid"), undefined),
 );

--- a/@coven/parsers/tests/parseInteger.test.ts
+++ b/@coven/parsers/tests/parseInteger.test.ts
@@ -1,20 +1,20 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { parseInteger } from "../parseInteger.ts";
 
 const parseDecimal = parseInteger(10);
 
 Deno.test("Parsing valid decimal string returns parsed value", () =>
-	assertEquals(parseDecimal("101"), 101),
+	assertStrictEquals(parseDecimal("101"), 101),
 );
 
 Deno.test("Parsing decimal string with a dot returns parsed value", () =>
-	assertEquals(parseDecimal("101.5"), 101),
+	assertStrictEquals(parseDecimal("101.5"), 101),
 );
 
 Deno.test("Parsing number with a weird radix returns parsed value", () =>
-	assertEquals(parseInteger(36)("z"), 35),
+	assertStrictEquals(parseInteger(36)("z"), 35),
 );
 
 Deno.test("Parsing invalid string returns undefined", () =>
-	assertEquals(parseDecimal("invalid"), undefined),
+	assertStrictEquals(parseDecimal("invalid"), undefined),
 );

--- a/@coven/parsers/tests/parseOctal.test.ts
+++ b/@coven/parsers/tests/parseOctal.test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { parseOctal } from "../parseOctal.ts";
 
 Deno.test("Parsing valid octal string returns parsed value", () =>
-	assertEquals(parseOctal("101"), 0o101),
+	assertStrictEquals(parseOctal("101"), 0o101),
 );
 
 Deno.test("Parsing octal string with a dot returns parsed value", () =>
-	assertEquals(parseOctal("101.5"), 0o101),
+	assertStrictEquals(parseOctal("101.5"), 0o101),
 );
 
 Deno.test("Parsing invalid string returns undefined", () =>
-	assertEquals(parseOctal("nope"), undefined),
+	assertStrictEquals(parseOctal("nope"), undefined),
 );

--- a/@coven/parsers/tests/undefineNaN.test.ts
+++ b/@coven/parsers/tests/undefineNaN.test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { undefineNaN } from "../undefineNaN.ts";
 
 Deno.test("Number returns the same number", () =>
-	assertEquals(undefineNaN(13), 13),
+	assertStrictEquals(undefineNaN(13), 13),
 );
 
 Deno.test("NaN returns undefined", () =>
-	assertEquals(undefineNaN(NaN), undefined),
+	assertStrictEquals(undefineNaN(NaN), undefined),
 );

--- a/@coven/predicates/deno.json
+++ b/@coven/predicates/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/predicates",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/rules/deno.json
+++ b/@coven/rules/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/rules",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/template/deno.json
+++ b/@coven/template/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/template",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/terminal/deno.json
+++ b/@coven/terminal/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/terminal",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/terminal/tests/format.test.ts
+++ b/@coven/terminal/tests/format.test.ts
@@ -1,29 +1,29 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { format } from "../format.ts";
 
 Deno.test("Format works on string", () =>
-	assertEquals(
+	assertStrictEquals(
 		format(13, 42)("Coven Engineering"),
 		"[13mCoven Engineering[42m",
 	),
 );
 
 Deno.test("Format works as a template tag function", () =>
-	assertEquals(
+	assertStrictEquals(
 		format(13, 42)`Coven Engineering ${665}`,
 		"[13mCoven Engineering 665[42m",
 	),
 );
 
 Deno.test("Nested when closing value is the same works", () =>
-	assertEquals(
+	assertStrictEquals(
 		format(13, 42)`Hi ${format(665, 42)`Witch`}!`,
 		"[13mHi [665mWitch[13m![42m",
 	),
 );
 
 Deno.test("Nested when closing value is the different works", () =>
-	assertEquals(
+	assertStrictEquals(
 		format(13, 42)`Hi ${format(665, 666)`Witch`}!`,
 		"[13mHi [665mWitch[666m![42m",
 	),

--- a/@coven/terminal/tests/mix.test.ts
+++ b/@coven/terminal/tests/mix.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { format } from "../format.ts";
 import { mix } from "../mix.ts";
 
@@ -7,14 +7,14 @@ const second = format(42, 42);
 const mixed = mix(first, second);
 
 Deno.test("Mix works", () =>
-	assertEquals(
+	assertStrictEquals(
 		mixed("Coven Engineering"),
 		second(first("Coven Engineering")),
 	),
 );
 
 Deno.test("Mix works as a template string tag function", () =>
-	assertEquals(
+	assertStrictEquals(
 		mixed`Coven Engineering ${13}`,
 		second`${first`Coven Engineering ${13}`}`,
 	),

--- a/@coven/terminal/tests/normalizeString.test.ts
+++ b/@coven/terminal/tests/normalizeString.test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { normalizeString } from "../normalizeString.ts";
 
 Deno.test("Normalize string works on a plain string", () =>
-	assertEquals(normalizeString("✨"), "✨"),
+	assertStrictEquals(normalizeString("✨"), "✨"),
 );
 
 Deno.test("Normalize string works as a template string tag function", () =>
-	assertEquals(normalizeString`${13}`, "13"),
+	assertStrictEquals(normalizeString`${13}`, "13"),
 );

--- a/@coven/types/deno.json
+++ b/@coven/types/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/types",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/utils/deno.json
+++ b/@coven/utils/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@coven/utils",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@coven/utils/tests/always.test.ts
+++ b/@coven/utils/tests/always.test.ts
@@ -1,8 +1,8 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { always } from "../always.ts";
 
 Deno.test("When passing a string, that string is returned when calling", () =>
-	assertEquals(always("✨")(), "✨"),
+	assertStrictEquals(always("✨")(), "✨"),
 );
 
 Deno.test(

--- a/@coven/utils/tests/createObject.test.ts
+++ b/@coven/utils/tests/createObject.test.ts
@@ -1,16 +1,16 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { createObject } from "../createObject.ts";
 
 const object = { "✨": "✨" } as const;
 
 Deno.test("Create empty object has no prototype", () =>
 	// deno-lint-ignore coven/no-null
-	assertEquals(Object.getPrototypeOf(createObject()), null),
+	assertStrictEquals(Object.getPrototypeOf(createObject()), null),
 );
 
 Deno.test("Create object has no prototype", () =>
 	// deno-lint-ignore coven/no-null
-	assertEquals(Object.getPrototypeOf(createObject(object)), null),
+	assertStrictEquals(Object.getPrototypeOf(createObject(object)), null),
 );
 
 Deno.test("Created object has all properties of original object", () =>

--- a/@coven/utils/tests/fnv1aReducer.test.ts
+++ b/@coven/utils/tests/fnv1aReducer.test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { fnv1aReducer } from "../fnv1aReducer.ts";
 import { FNV_OFFSET_32 } from "../FNV_OFFSET_32.ts";
 
 Deno.test(
 	'1 cryptoNumber call with a "test" seed returns the same result',
-	() => assertEquals(fnv1aReducer(FNV_OFFSET_32, 13), 135029208),
+	() => assertStrictEquals(fnv1aReducer(FNV_OFFSET_32, 13), 135029208),
 );
 
 Deno.test(

--- a/@coven/utils/tests/seededRandom.test.ts
+++ b/@coven/utils/tests/seededRandom.test.ts
@@ -1,9 +1,9 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { seededRandom } from "../seededRandom.ts";
 
 Deno.test(
 	'1 cryptoNumber call with a "test" seed returns the same result',
-	() => assertEquals(seededRandom("test"), 0.069_744_775_770_232_08),
+	() => assertStrictEquals(seededRandom("test"), 0.069_744_775_770_232_08),
 );
 
 Deno.test(

--- a/@coven/utils/tests/stringify.test.ts
+++ b/@coven/utils/tests/stringify.test.ts
@@ -1,43 +1,43 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { stringify } from "../stringify.ts";
 
 Deno.test("Stringifies booleans as expected", () =>
 	// deno-lint-ignore no-boolean-literal-for-arguments
-	assertEquals(stringify(true), "true"),
+	assertStrictEquals(stringify(true), "true"),
 );
 
 Deno.test("Stringifies null as expected", () =>
 	// deno-lint-ignore coven/no-null
-	assertEquals(stringify(null), "null"),
+	assertStrictEquals(stringify(null), "null"),
 );
 
 Deno.test("Stringifies undefined as expected", () =>
-	assertEquals(stringify(undefined), "undefined"),
+	assertStrictEquals(stringify(undefined), "undefined"),
 );
 
 Deno.test("Stringifies numbers as expected", () =>
-	assertEquals(stringify(13), "13"),
+	assertStrictEquals(stringify(13), "13"),
 );
 
 Deno.test("Stringifies bigints as expected", () =>
-	assertEquals(stringify(13n), "13"),
+	assertStrictEquals(stringify(13n), "13"),
 );
 
 Deno.test("Stringifies string as expected", () =>
-	assertEquals(stringify("Coven"), "Coven"),
+	assertStrictEquals(stringify("Coven"), "Coven"),
 );
 
 Deno.test("Stringifies symbol as expected", () =>
-	assertEquals(stringify(Symbol("Coven")), "Symbol(Coven)"),
+	assertStrictEquals(stringify(Symbol("Coven")), "Symbol(Coven)"),
 );
 
 Deno.test("Stringifies function as expected", () =>
-	assertEquals(
+	assertStrictEquals(
 		stringify(() => {}),
 		"()=>{}",
 	),
 );
 
 Deno.test("Stringifies objects as expected", () =>
-	assertEquals(stringify({}), "[object Object]"),
+	assertStrictEquals(stringify({}), "[object Object]"),
 );

--- a/@coven/utils/tests/thunk.test.ts
+++ b/@coven/utils/tests/thunk.test.ts
@@ -1,9 +1,9 @@
-import { assertEquals } from "@std/assert";
+import { assertStrictEquals } from "@std/assert";
 import { thunk } from "../thunk.ts";
 
 const double = (value: number) => value * 2;
 const thunkDouble = thunk(double);
 
 Deno.test("Thunk for a double function returns delayed double function", () =>
-	assertEquals(thunkDouble(21)(), 42),
+	assertStrictEquals(thunkDouble(21)(), 42),
 );

--- a/@simulcast/core/deno.json
+++ b/@simulcast/core/deno.json
@@ -2,5 +2,5 @@
 	"$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
 	"exports": "./mod.ts",
 	"name": "@simulcast/core",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@simulcast/preact/deno.json
+++ b/@simulcast/preact/deno.json
@@ -11,5 +11,5 @@
 		"preact": "npm:preact@^10.29.1"
 	},
 	"name": "@simulcast/preact",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@simulcast/react/deno.json
+++ b/@simulcast/react/deno.json
@@ -12,5 +12,5 @@
 		"react": "npm:react@^19.2.5"
 	},
 	"name": "@simulcast/react",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/@simulcast/vue/deno.json
+++ b/@simulcast/vue/deno.json
@@ -6,5 +6,5 @@
 		"vue": "npm:vue@^3.5.32"
 	},
 	"name": "@simulcast/vue",
-	"version": "0.9.4"
+	"version": "0.9.5"
 }

--- a/deno.json
+++ b/deno.json
@@ -72,9 +72,12 @@
 	},
 	"nodeModulesDir": "auto",
 	"tasks": {
+		"ci": {
+			"command": "deno clean && deno install && deno lint && deno task lint-docs && deno publish --dry-run && deno task format-check && deno task test-coverage",
+			"description": "Run all commands that run on CI"
+		},
 		"format": {
-			"TMPDIR=. deno run --allow-env=TMPDIR --allow-read=. --allow-sys=cpus --allow-write=. --ignore-env --log-level=warn --no-prompt prettier --write './**/*.{json,md,ts,tsx}'": "",
-			"command": "TMPDIR=. deno run --allow-env=TMPDIR --allow-read=. --allow-sys=cpus --allow-write=. --ignore-env --no-prompt prettier --log-level=warn --write './**/*.{json,md,ts,tsx}'",
+			"command": "TMPDIR=. deno run --allow-env=TMPDIR --allow-read=. --allow-sys=cpus --allow-write=. --ignore-env --log-level=warn --no-prompt prettier --write './**/*.{json,md,ts,tsx}'",
 			"description": "Format code using Prettier"
 		},
 		"format-check": {


### PR DESCRIPTION
Followup of recent `@coven/math` changes, with more cleanup:

- Memoize some `@coven/cron` functions.
- Remove fallback for `fallback` in `numberFunction` in `@coven/math`.
- Turn a bunch of `assertEquals` into `assertStrictEquals` in tests.
- Version bump.
- New `ci` task for `deno` to run the same stuff that runs when pushing code.