### PR TITLE
Add coverage thresholds.

### DIFF
--- a/@coven/cron/Field.ts
+++ b/@coven/cron/Field.ts
@@ -11,6 +11,4 @@ import type { ValueOrRangeField } from "./ValueOrRangeField.ts";
  * @see {@linkcode ListField}
  */
 export type Field<Value extends number> =
-	| AllToken
-	| ListField<Value>
-	| ValueOrRangeField<Value>;
+	AllToken | ListField<Value> | ValueOrRangeField<Value>;

--- a/@coven/iterables/async/initial.ts
+++ b/@coven/iterables/async/initial.ts
@@ -25,7 +25,7 @@ export const initial = <Iterable extends AwaitableIterable>(
 			let item = await iterator.next();
 
 			// deno-lint-ignore coven/no-for
-			for (; !item.done; ) {
+			for (; !item.done;) {
 				const value = item.value;
 
 				// deno-lint-ignore no-await-in-loop

--- a/@coven/iterables/initial.ts
+++ b/@coven/iterables/initial.ts
@@ -25,7 +25,7 @@ export const initial = <IterableToGetInitial extends Iterable<unknown>>(
 		const iterator = getIterator(iterable);
 
 		// deno-lint-ignore coven/no-for
-		for (let item = iterator.next(); !item.done; ) {
+		for (let item = iterator.next(); !item.done;) {
 			const value = item.value;
 
 			item = iterator.next();

--- a/@coven/math/PreciseString.ts
+++ b/@coven/math/PreciseString.ts
@@ -2,5 +2,4 @@
  * Possible `string` representations of `Precise`.
  */
 export type PreciseString =
-	| "NaN"
-	| `${"-" | ""}${`${bigint}` | `${bigint}.${bigint}`}`;
+	"NaN" | `${"-" | ""}${`${bigint}` | `${bigint}.${bigint}`}`;

--- a/@coven/math/preciseRound.ts
+++ b/@coven/math/preciseRound.ts
@@ -32,7 +32,7 @@ export const preciseRound: Unary<[precise: Precise], Precise> = memoFunction(
 				let coefficient = getPreciseCoefficient(value);
 
 				// deno-lint-ignore coven/no-for
-				for (; exponent < 0n; ) {
+				for (; exponent < 0n;) {
 					const rem = coefficient % 10n;
 					coefficient /= 10n;
 					exponent += 1n;

--- a/@coven/math/preciseTruncate.ts
+++ b/@coven/math/preciseTruncate.ts
@@ -32,7 +32,7 @@ export const preciseTruncate: Unary<[precise: Precise], Precise> = memoFunction(
 				let coefficient = getPreciseCoefficient(value);
 
 				// deno-lint-ignore coven/no-for
-				for (; exponent < 0n; ) {
+				for (; exponent < 0n;) {
 					coefficient /= 10n;
 					exponent += 1n;
 				}

--- a/@coven/template/TemplateHandlers.ts
+++ b/@coven/template/TemplateHandlers.ts
@@ -15,6 +15,5 @@ import type { Stringable, TypeOfDictionary } from "@coven/types";
  */
 export type TemplateHandlers = {
 	readonly [Key in keyof TypeOfDictionary]?:
-		| ((expression: TypeOfDictionary[Key]) => Stringable)
-		| Stringable;
+		((expression: TypeOfDictionary[Key]) => Stringable) | Stringable;
 };

--- a/@coven/types/EntryOf.ts
+++ b/@coven/types/EntryOf.ts
@@ -17,12 +17,14 @@ import type { ReadonlyArrayLike } from "./ReadonlyArrayLike.ts";
  * @see {@linkcode ReadonlyArrayLike}
  * @template Object Object to get the entry from.
  */
-export type EntryOf<Object extends object> = Readonly<{
-	/**
-	 * @see {@linkcode EntryOf} property that shouldn't be referenced directly
-	 */
-	[Property in keyof Object]: Entry<
-		NormalizeEntryKey<Property>,
-		Object extends ReadonlyArrayLike ? Object[number] : Object[Property]
-	>;
-}>[keyof Object];
+export type EntryOf<Object extends object> = Readonly<
+	{
+		/**
+		 * @see {@linkcode EntryOf} property that shouldn't be referenced directly
+		 */
+		[Property in keyof Object]: Entry<
+			NormalizeEntryKey<Property>,
+			Object extends ReadonlyArrayLike ? Object[number] : Object[Property]
+		>;
+	}
+>[keyof Object];

--- a/@coven/types/ISODayOfMonth.ts
+++ b/@coven/types/ISODayOfMonth.ts
@@ -11,6 +11,4 @@ import type { Digit } from "./Digit.ts";
  * @see {@linkcode https://coven.to/mdn/Date Date}
  */
 export type ISODayOfMonth =
-	| `${1 | 2}${Digit}`
-	| `0${Exclude<Digit, 0>}`
-	| `3${0 | 1}`;
+	`${1 | 2}${Digit}` | `0${Exclude<Digit, 0>}` | `3${0 | 1}`;

--- a/@coven/types/NormalizeEntryKey.ts
+++ b/@coven/types/NormalizeEntryKey.ts
@@ -10,5 +10,4 @@
  * @template EntryKey `PropertyKey` to be stringified.
  */
 export type NormalizeEntryKey<EntryKey extends PropertyKey> =
-	| Exclude<EntryKey, number>
-	| `${Extract<EntryKey, number>}`;
+	Exclude<EntryKey, number> | `${Extract<EntryKey, number>}`;

--- a/@simulcast/core/BroadcastObject.ts
+++ b/@simulcast/core/BroadcastObject.ts
@@ -36,9 +36,9 @@ export type BroadcastObject<Events extends EventTypeDictionary> = Readonly<
 		/**
 		 * Dynamically generated `emit`.
 		 */
-		[Event in keyof Events as `emit${Capitalize<keyof Events & string>}`]: EventHandler<
-			Events[Event]
-		>;
+		[
+			Event in keyof Events as `emit${Capitalize<keyof Events & string>}`
+		]: EventHandler<Events[Event]>;
 	} & {
 		/**
 		 * Dynamically generated `on`.

--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,9 @@
 		"noUnusedParameters": true,
 		"strict": true
 	},
+	"coverage": {
+		"thresholds": { "branches": 100, "functions": 100, "lines": 100 }
+	},
 	"exclude": ["coverage"],
 	"fmt": {
 		"bracePosition": "sameLine",


### PR DESCRIPTION
`deno` now supports configuring coverage thresholds. With this config we can ensure the coverage is kept at a 100%.