### PR TITLE
Enable TypeScript Go support in Deno

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,13 @@ on:
         branches:
             - "**"
 
+env:
+    DENO_UNSTABLE_TSGO: 1
+
 jobs:
     test:
         name: Run Tests
-        runs-on: ubuntu-slim
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             id-token: write

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -27,5 +27,23 @@
 			]
 		}
 	},
-	"lsp": { "deno": { "settings": { "deno": { "enable": true } } } }
+	"lsp": {
+		"deno": { "settings": { "deno": { "enable": true } } },
+		"json-language-server": {
+			"settings": {
+				"json": {
+					"schemas": [
+						{
+							"fileMatch": ["deno.json", "deno.jsonc"],
+							"url": "https://raw.githubusercontent.com/denoland/deno/refs/heads/main/cli/schemas/config-file.v1.json"
+						},
+						{
+							"fileMatch": ["package.json"],
+							"url": "https://www.schemastore.org/package"
+						}
+					]
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
- Add `DENO_UNSTABLE_TSGO` to `env` of CI.
- Update `.zed/settings.json` to have better auto-completion.